### PR TITLE
fix: esbuild-plugin-copy error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
+node_modules
+.env
 .DS_Store

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -76,8 +76,8 @@ esbuild.build({
 		...(prod ? [copy({
 			resolveFrom: 'cwd',
 			assets: {
-			  from: ['./manifest.json'],
-			  to: [outputDir+'/manifest.json'],
+			  from: 'manifest.json',
+			  to: outputDir+'/manifest.json',
 			},
 		  })] : []),
 	],


### PR DESCRIPTION
Hello,
I noticed that on my computer esbuild-plugin-copy gives an error when building with in production (`npm run build`).

```
> make-md@0.5.0 build
> tsc -noEmit -skipLibCheck && node esbuild.config.mjs production


  production/main.js   826.2kb
  production/main.css   17.7kb

⚡ Done in 91ms
Renaming production/main.css to production/styles.css
✘ [ERROR] [plugin plugin:copy] EEXIST: file already exists, mkdir '/Users/syncroit/Projects/makemd/production/manifest.json'

    /Users/syncroit/Projects/makemd/node_modules/fs-extra/lib/mkdirs/make-dir.js:23:12:
      23 │   return fs.mkdirSync(dir, {
         ╵             ^

    at Object.mkdirSync (fs.js:1014:3)
    at Object.module.exports.makeDirSync (/Users/syncroit/Projects/makemd/node_modules/fs-extra/lib/mkdirs/make-dir.js:23:13)
    at keepStructureCopyHandler (/Users/syncroit/Projects/makemd/node_modules/esbuild-plugin-copy/dist/lib/handler/keep-raw-structure.js:29:39)
    at /Users/syncroit/Projects/makemd/node_modules/esbuild-plugin-copy/dist/lib/esbuild-plugin-copy.js:60:85
    at Array.forEach (<anonymous>)
    at /Users/syncroit/Projects/makemd/node_modules/esbuild-plugin-copy/dist/lib/esbuild-plugin-copy.js:58:28
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async /Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:1040:15

  This error came from the "onEnd" callback registered here:

    /Users/syncroit/Projects/makemd/node_modules/esbuild-plugin-copy/dist/lib/esbuild-plugin-copy.js:20:28:
      20 │             build[applyHook](async () => {
         ╵                             ^

    at setup (/Users/syncroit/Projects/makemd/node_modules/esbuild-plugin-copy/dist/lib/esbuild-plugin-copy.js:20:29)
    at handlePlugins (/Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:843:23)
    at Object.buildOrServe (/Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:1137:7)
    at /Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:2085:17
    at new Promise (<anonymous>)
    at Object.build (/Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:2084:14)
    at Object.build (/Users/syncroit/Projects/makemd/node_modules/esbuild/lib/main.js:1931:51)
    at file:///Users/syncroit/Projects/makemd/esbuild.config.mjs:49:9
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)

1 error

```

My OS: MacOS Ventura 13.0.1

Apparently esbuild-plugin-copy recognizes the path of the manifest.json as a folder and so tries to create a folder instead of copying the file only. I fixed this by writing the path to manifest.json without a dot before it.

I also added node_modules and .env to .gitignore.