### PR TITLE
fix: ensure ViewModal defaults to previous name when renaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "make-md",
-    "version": "0.6.7",
+    "version": "0.7.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "make-md",
-            "version": "0.6.7",
+            "version": "0.7.14",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.3.0",
@@ -388,53 +388,69 @@
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
+            "integrity": "sha512-cY3aYc1FhZdiE9wUn474Kw+l288fmWZsrfLv8fR8/5q3rcUlYO+YoHewwPDV3L0sJBh48qCKORA/+PqQG7rDYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+                "@webassemblyjs/helper-numbers": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
+                "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+            "integrity": "sha512-z+6ExkIgehxOYG/AgXzBrkCJXAA9FmylpeE/85lYPounBo/eylW6NsvOkVcvzL5KETdKdxSbP0dCwxzAA5TFYA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+            "integrity": "sha512-s47oO2lTrZ4YetGYyu7P4ueUZ3Zl+UfzGySLUFkPlxrV8amp4ySeiG0cS4zE54WYJ5ajG8x+kPcj+wmJmqjc8A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-code-frame": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
+            "integrity": "sha512-aF2xsJ/LYz6ld4+zNDJ8AsynC3g0UiP1/u+HExz6bPFq55VP7RL0/v22tixuzlfpVkOOrtapt9DL+uFJYSZoZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/wast-printer": "1.11.1"
+                "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-wast-printer.tgz"
             }
         },
         "node_modules/@webassemblyjs/helper-fsm": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
+            "integrity": "sha512-7GIVVj64wX4PZxQ89p/GjcMgMQW68DikfzSg18neCJvHa6d8+M0G1oUeeu2L+VfKf3DH9qfGwDjjwHiyMeATAg==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
+            "integrity": "sha512-G9XJ1H90Po0cIEUgi3JlEg5x35k1WTjIhT1OSa6dWjP6Gu4H3unqUkdbnBHmgrdBx/TKuhm0fHarsIyGsneMSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
+            "integrity": "sha512-XPAPtrVginHTCjk4taKHVZq7A1mC8zcLrNS3PTWzR84IX1RUdVI7XpAulr6F6bzBHrpRfm8JDq9PhLxCqEjgvA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/ieee754": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
+            "integrity": "sha512-xhKvCB2yysf6hg7LE52/0Q4DK9ydWkZIPwhQuGBtatSjwxU1oFd7JxQe+oqd8bmrYEd/W86Cq1FfA81IOpKTqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -443,6 +459,8 @@
         },
         "node_modules/@webassemblyjs/leb128": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
+            "integrity": "sha512-eXvoK2Q3MG9IXIRmVncysJDk2y7ImoztWbbRE/UytbBAFkw/c2qxTVty3gX2YhoRjAvv9/ifBqVkBZ8uh4/KSg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -451,53 +469,63 @@
         },
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz",
+            "integrity": "sha512-K0M8V6g1+k4hSoP/XdPvAN2y7A2FYP5IThWUTRSif1KhbiggxF1jbiVoq7YLCucWA8MZs/f5p257KKqtSKXP1A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-parser": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
+            "integrity": "sha512-/jo3/7k69tIuWln/HaHKhTfm3f3zISDmCXKVFeGPc3XMPLr11EY0p3zPyHG1SKHkWETdG5LJIhMaD+CAlfk6qg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+                "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
+                "@webassemblyjs/ieee754": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
+                "@webassemblyjs/leb128": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
+                "@webassemblyjs/utf8": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz"
             }
         },
         "node_modules/@webassemblyjs/wast-parser": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
+            "integrity": "sha512-DVGZfBnzYbqyHuvAKGiDc8gw0s0MITY2zrsPGvtx2XpaNJ1tHaeNpyOHs+GvN6/k7VsuEmNqrIzTpl6apw1oSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-code-frame": "1.11.1",
-                "@webassemblyjs/helper-fsm": "1.11.1",
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
+                "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+                "@webassemblyjs/helper-code-frame": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
+                "@webassemblyjs/helper-fsm": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
             "version": "1.11.1",
+            "resolved": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
+            "integrity": "sha512-WFuDIpmoSfU0Du2GA/UGluMJLgKWALsGPcvkDFg3GDgxdDyva1hIW+8K6frSbv/YTwo50gBhW5dw4OB7cr6T5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
-            "dev": true,
-            "license": "Apache-2.0"
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -522,9 +550,10 @@
             }
         },
         "node_modules/binaryen": {
-            "version": "111.0.0",
+            "version": "112.0.0",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-112.0.0.tgz",
+            "integrity": "sha512-5QsGh9YIHRbwxa8qMe0FaG8QVpoS+fyQal1Wapdmd1UNs5hTxhJP5ROl3q1nT5egQVWffO9sKp6fshRQ4IhIHg==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "wasm-opt": "bin/wasm-opt",
                 "wasm2js": "bin/wasm2js"
@@ -1087,7 +1116,8 @@
             }
         },
         "node_modules/obsidian-daily-notes-interface/node_modules/obsidian": {
-            "version": "1.1.7",
+            "version": "1.2.8",
+            "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1452,9 +1482,10 @@
             "license": "MIT"
         },
         "node_modules/wabt": {
-            "version": "1.0.30",
+            "version": "1.0.32",
+            "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.32.tgz",
+            "integrity": "sha512-1aHvkKaSrrl7qFtAbQ1RWVHLuJApRh7PtUdYvRtiUEKEhk0MOV0sTuz5cLF6jL5jPLRyifLbZcR65AEga/xBhQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "wasm-decompile": "bin/wasm-decompile",
                 "wasm-interp": "bin/wasm-interp",
@@ -1729,101 +1760,118 @@
             }
         },
         "@webassemblyjs/ast": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-ast.tgz",
+            "integrity": "sha512-cY3aYc1FhZdiE9wUn474Kw+l288fmWZsrfLv8fR8/5q3rcUlYO+YoHewwPDV3L0sJBh48qCKORA/+PqQG7rDYA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-numbers": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+                "@webassemblyjs/helper-numbers": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
+                "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+            "integrity": "sha512-z+6ExkIgehxOYG/AgXzBrkCJXAA9FmylpeE/85lYPounBo/eylW6NsvOkVcvzL5KETdKdxSbP0dCwxzAA5TFYA==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+            "integrity": "sha512-s47oO2lTrZ4YetGYyu7P4ueUZ3Zl+UfzGySLUFkPlxrV8amp4ySeiG0cS4zE54WYJ5ajG8x+kPcj+wmJmqjc8A==",
             "dev": true
         },
         "@webassemblyjs/helper-code-frame": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
+            "integrity": "sha512-aF2xsJ/LYz6ld4+zNDJ8AsynC3g0UiP1/u+HExz6bPFq55VP7RL0/v22tixuzlfpVkOOrtapt9DL+uFJYSZoZQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/wast-printer": "1.11.1"
+                "@webassemblyjs/wast-printer": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-wast-printer.tgz"
             }
         },
         "@webassemblyjs/helper-fsm": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
+            "integrity": "sha512-7GIVVj64wX4PZxQ89p/GjcMgMQW68DikfzSg18neCJvHa6d8+M0G1oUeeu2L+VfKf3DH9qfGwDjjwHiyMeATAg==",
             "dev": true
         },
         "@webassemblyjs/helper-numbers": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-numbers.tgz",
+            "integrity": "sha512-G9XJ1H90Po0cIEUgi3JlEg5x35k1WTjIhT1OSa6dWjP6Gu4H3unqUkdbnBHmgrdBx/TKuhm0fHarsIyGsneMSA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
+            "integrity": "sha512-XPAPtrVginHTCjk4taKHVZq7A1mC8zcLrNS3PTWzR84IX1RUdVI7XpAulr6F6bzBHrpRfm8JDq9PhLxCqEjgvA==",
             "dev": true
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
+            "integrity": "sha512-xhKvCB2yysf6hg7LE52/0Q4DK9ydWkZIPwhQuGBtatSjwxU1oFd7JxQe+oqd8bmrYEd/W86Cq1FfA81IOpKTqA==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
+            "integrity": "sha512-eXvoK2Q3MG9IXIRmVncysJDk2y7ImoztWbbRE/UytbBAFkw/c2qxTVty3gX2YhoRjAvv9/ifBqVkBZ8uh4/KSg==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz",
+            "integrity": "sha512-K0M8V6g1+k4hSoP/XdPvAN2y7A2FYP5IThWUTRSif1KhbiggxF1jbiVoq7YLCucWA8MZs/f5p257KKqtSKXP1A==",
             "dev": true
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wasm-parser.tgz",
+            "integrity": "sha512-/jo3/7k69tIuWln/HaHKhTfm3f3zISDmCXKVFeGPc3XMPLr11EY0p3zPyHG1SKHkWETdG5LJIhMaD+CAlfk6qg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+                "@webassemblyjs/helper-wasm-bytecode": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-wasm-bytecode.tgz",
+                "@webassemblyjs/ieee754": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ieee754.tgz",
+                "@webassemblyjs/leb128": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-leb128.tgz",
+                "@webassemblyjs/utf8": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-utf8.tgz"
             }
         },
         "@webassemblyjs/wast-parser": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-parser.tgz",
+            "integrity": "sha512-DVGZfBnzYbqyHuvAKGiDc8gw0s0MITY2zrsPGvtx2XpaNJ1tHaeNpyOHs+GvN6/k7VsuEmNqrIzTpl6apw1oSQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-code-frame": "1.11.1",
-                "@webassemblyjs/helper-fsm": "1.11.1",
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
+                "@webassemblyjs/floating-point-hex-parser": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-floating-point-hex-parser.tgz",
+                "@webassemblyjs/helper-api-error": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-api-error.tgz",
+                "@webassemblyjs/helper-code-frame": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-code-frame.tgz",
+                "@webassemblyjs/helper-fsm": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-helper-fsm.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.11.1",
+            "version": "https://github.com/mitschabaude/webassemblyjs/releases/latest/download/webassemblyjs-wast-printer.tgz",
+            "integrity": "sha512-WFuDIpmoSfU0Du2GA/UGluMJLgKWALsGPcvkDFg3GDgxdDyva1hIW+8K6frSbv/YTwo50gBhW5dw4OB7cr6T5Q==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/ast": "https://github.com/mitschabaude/webassemblyjs/releases/download/v1.11.1-3/webassemblyjs-ast.tgz",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true
         },
         "@xtuc/long": {
             "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -1838,7 +1886,9 @@
             "dev": true
         },
         "binaryen": {
-            "version": "111.0.0",
+            "version": "112.0.0",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-112.0.0.tgz",
+            "integrity": "sha512-5QsGh9YIHRbwxa8qMe0FaG8QVpoS+fyQal1Wapdmd1UNs5hTxhJP5ROl3q1nT5egQVWffO9sKp6fshRQ4IhIHg==",
             "dev": true
         },
         "braces": {
@@ -2195,8 +2245,9 @@
             },
             "dependencies": {
                 "obsidian": {
-                    "version": "1.1.7",
+                    "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
                     "dev": true,
+                    "from": "obsidian@obsidianmd/obsidian-api#master",
                     "requires": {
                         "@types/codemirror": "0.0.108",
                         "moment": "2.29.4"
@@ -2394,7 +2445,9 @@
             "version": "2.2.6"
         },
         "wabt": {
-            "version": "1.0.30",
+            "version": "1.0.32",
+            "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.32.tgz",
+            "integrity": "sha512-1aHvkKaSrrl7qFtAbQ1RWVHLuJApRh7PtUdYvRtiUEKEhk0MOV0sTuz5cLF6jL5jPLRyifLbZcR65AEga/xBhQ==",
             "dev": true
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "make-md",
-    "version": "0.6.9",
+    "version": "0.7.14",
     "description": "make.md",
     "main": "main.js",
     "scripts": {

--- a/src/components/ui/modals/saveViewModal.ts
+++ b/src/components/ui/modals/saveViewModal.ts
@@ -4,6 +4,21 @@ import { MDBSchema } from "types/mdb";
 import i18n from "i18n";
 
 type ViewAction = "rename table" | "rename view" | "new view" | "new table";
+
+const buttonTexts: Record<ViewAction, string> = {
+  "new table": i18n.buttons.saveTable,
+  "new view": i18n.buttons.saveView,
+  "rename view": i18n.buttons.renameView,
+  "rename table": i18n.buttons.renameTable,
+};
+
+const headerTexts: Record<ViewAction, string> = {
+  "new table": i18n.labels.saveTable,
+  "new view": i18n.labels.saveView,
+  "rename view": i18n.labels.renameView,
+  "rename table": i18n.labels.renameTable,
+};
+
 export class SaveViewModal extends Modal {
   schema: MDBSchema;
   saveSchema: (schema: MDBSchema) => void;
@@ -24,37 +39,17 @@ export class SaveViewModal extends Modal {
     let { contentEl } = this;
     let myModal = this;
 
-    // Header
-    let headerText;
-    if (this.action == "new view")
-      headerText = i18n.labels.saveView;
-    if (this.action == "new table")
-      headerText = i18n.labels.saveTable;
-    if (this.action == "rename view")
-      headerText = i18n.labels.renameView;
-    if (this.action == "rename table")
-      headerText = i18n.labels.renameTable;
-
+    const headerText = headerTexts[this.action];
     const headerEl = contentEl.createEl("div", { text: headerText });
     headerEl.addClass("modal-title");
 
-    // Input El
-    const inputEl = contentEl.createEl("input");
-
+    const inputEl = contentEl.createEl("input", {
+      value: this.schema.name,
+    });
     inputEl.style.cssText = "width: 100%; height: 2.5em; margin-bottom: 15px;";
     inputEl.focus();
 
-    // Buttons
-    let changeButtonText;
-    if (this.action == "new view")
-      changeButtonText = i18n.buttons.saveView;
-    if (this.action == "new table")
-      changeButtonText = i18n.buttons.saveTable;
-    if (this.action == "rename view")
-      changeButtonText = i18n.buttons.renameView;
-    if (this.action == "rename table")
-      changeButtonText = i18n.buttons.renameTable;
-
+    const changeButtonText = buttonTexts[this.action];
     const changeButton = contentEl.createEl("button", {
       text: changeButtonText,
     });
@@ -68,7 +63,7 @@ export class SaveViewModal extends Modal {
     });
 
     const onClickAction = async () => {
-      let newName = inputEl.value;
+      const newName = inputEl.value;
       if (this.action == "new view" || this.action == "new table") {
         this.saveSchema({ ...this.schema, id: newName, name: newName });
       } else {


### PR DESCRIPTION
**Current behaviour:**
- When renaming a view, the input is presented empty

**Expected behaviour:**
- When renaming, show the old name in the input
- Same as Spaces

Also bumped the package.json version and did a bit of housekeeping on the way the texts are obtained ^^