### PR TITLE
fix(navigator): make space name visible in notion theme

### DIFF
--- a/src/css/Panels/Navigator/Navigator.css
+++ b/src/css/Panels/Navigator/Navigator.css
@@ -152,6 +152,7 @@ opacity: 1;
   display: flex;
   gap: 4px;
   flex-grow: 0 !important;
+  flex-basis: 100%;
 }
 .mk-sidebar:hover .mk-tree-new {
   opacity: .5


### PR DESCRIPTION
When using the Obsidian Notion theme with Spaces, the Space Name is not shown properly. https://github.com/diegoeis/obsidianotion/issues/17

![image](https://github.com/user-attachments/assets/d3b5d053-0661-420e-9c49-63433b1b8352)

Adding a `flex-basis: 100%` property to the header will fix this.