### PR TITLE
fix: Property saving and synchronization improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 undefined
 .vscode
+data.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "make.md",
   "main": "main.js",
   "scripts": {
-    "dev": "nnode esbuild.config.mjs",
+    "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "preview": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs preview",
     "demo": "&& node esbuild.config.mjs demo",

--- a/src/core/react/components/Explorer/PropertiesView.tsx
+++ b/src/core/react/components/Explorer/PropertiesView.tsx
@@ -128,11 +128,21 @@ export const PropertiesView = (props: {
     }
   };
 
+  const pathChanged = (payload: { path: string }) => {
+    if (payload.path == pathState?.path) {
+      refreshData();
+    }
+  };
+
   useEffect(() => {
     refreshData();
     props.superstate.eventsDispatcher.addListener(
       "contextStateUpdated",
       mdbChanged
+    );
+    props.superstate.eventsDispatcher.addListener(
+      "pathStateUpdated",
+      pathChanged
     );
 
     return () => {
@@ -140,8 +150,12 @@ export const PropertiesView = (props: {
         "contextStateUpdated",
         mdbChanged
       );
+      props.superstate.eventsDispatcher.removeListener(
+        "pathStateUpdated",
+        pathChanged
+      );
     };
-  }, [props.spaces, tableData]);
+  }, [props.spaces, tableData, pathState]);
   const savePropertyValue = (value: string, f: SpaceTableColumn) => {
     if (saveProperty) {
       const property = tableData?.cols?.find((g) => g.name == f.name);

--- a/src/core/react/components/SpaceView/Contexts/DataTypeView/OptionCell.tsx
+++ b/src/core/react/components/SpaceView/Contexts/DataTypeView/OptionCell.tsx
@@ -66,11 +66,11 @@ export const OptionCell = (
         .map((t, index) => ({
           ...t,
           color: editable
-            ? schemeColors
+            ? t.color?.length > 0
+              ? t.color  // Use individual option color if set
+              : schemeColors
               ? schemeColors[index % schemeColors.length]?.value ||
                 "var(--mk-color-none)"
-              : t.color?.length > 0
-              ? t.color
               : undefined
             : undefined,
           removeable: editable ? editMode >= CellEditMode.EditModeView : false,

--- a/src/core/react/components/UI/Menus/contexts/PropertyValue.tsx
+++ b/src/core/react/components/UI/Menus/contexts/PropertyValue.tsx
@@ -444,10 +444,11 @@ export const PropertyValueComponent = (props: {
     const options = parseOptions(parsedValue.options ?? []);
 
     const saveOptionsHandler = (newOptions: SelectOption[], colorScheme?: string) => {
-      saveParsedValue("options", newOptions);
+      const updated: Record<string, any> = { ...parsedValue, options: newOptions };
       if (colorScheme !== undefined) {
-        saveParsedValue("colorScheme", colorScheme);
+        updated.colorScheme = colorScheme;
       }
+      props.saveValue(JSON.stringify(updated));
     };
 
     props.superstate.ui.openModal(

--- a/src/core/react/components/UI/Modals/EditOptionsModal.tsx
+++ b/src/core/react/components/UI/Modals/EditOptionsModal.tsx
@@ -78,13 +78,17 @@ const SortableOptionItem: React.FC<SortableOptionItemProps> = ({
     e.preventDefault();
     
     // Always show color picker menu regardless of color scheme
-    showColorPickerMenu(
+    const menu = showColorPickerMenu(
       superstate,
       (e.target as HTMLElement).getBoundingClientRect(),
       windowFromDocument(e.view.document),
       option.color || "var(--mk-color-none)",
       (color: string) => {
         onEdit({ ...option, color });
+        // Auto-close menu after color selection
+        if (menu) {
+          menu.hide();
+        }
       }
     );
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "inlineSources": true,
     "isolatedModules": true,
     "module": "ESNext",
-    "target": "es6",
+    "target": "es2020",
     "allowJs": true,
     "alwaysStrict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Summary
Fixed multiple issues with property saving and synchronization in the Make.md plugin:

1. **Option and color scheme saving** - Options and color schemes now save correctly
2. **Color application** - Individual option colors are properly applied and preserved
3. **UI/UX improvements** - Color picker closes automatically after selection
4. **Property synchronization** - Checkbox and other properties now sync between top and bottom sections

## Issues Fixed
- Options in table property dropdown not saving
- Color changes not being applied to options
- Color picker not closing after selection
- Checkbox properties not syncing between inline properties and Properties section

## Changes

### 1. Atomic saving of options and color schemes (`PropertyValue.tsx`)
- Modified `saveOptionsHandler` to perform atomic update of both `options` and `colorScheme`
- Prevents data loss when saving multiple related properties

### 2. Color priority fix (`OptionCell.tsx`)
- Individual option colors now take priority over color scheme
- Preserves user-set colors while still applying scheme colors to new options

### 3. Auto-close color picker (`EditOptionsModal.tsx`)
- Added `hide` callback to `showColorPickerMenu` 
- Color picker now closes automatically after color selection

### 4. Property synchronization (`PropertiesView.tsx`)
- Added listener for `pathStateUpdated` event
- Properties now refresh immediately when saved
- Fixed checkbox sync between inline properties and Properties section

### 5. Build improvements
- Updated TypeScript target to `es2020` for consistency with esbuild
- Fixed typo in `package.json` dev script
- Added `data.json` to `.gitignore`

## Testing
- ✅ Options save correctly in table property dropdown
- ✅ Colors apply and persist on options
- ✅ Color picker closes after selection
- ✅ Checkboxes sync between property sections
- ✅ Build process works correctly

## Compatibility
- No breaking changes
- Maintains backward compatibility with existing data
- TypeScript target updated to `es2020` (aligns with esbuild config)